### PR TITLE
Create an HTTP API to explicitly login to Yellowfin

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -107,8 +107,10 @@ func exec(cmdName string, args []string, options cli.OptionSet) {
 	}
 
 	// Because Yellowfin only allows a single session per user, we need to
-	// make our behaviour the same.
-	if ic.Config.Yellowfin.Enabled {
+	// make our behaviour the same. Note that this is only true for the Legacy case.
+	// When using our new Router-based "transparent" yellowfin login, this
+	// restriction falls away.
+	if ic.Config.Yellowfin.Enabled && ic.Config.Yellowfin.UseLegacyAuth {
 		ic.Config.Authaus.SessionDB.MaxActiveSessions = 1
 	}
 

--- a/imqsauth/config.go
+++ b/imqsauth/config.go
@@ -11,6 +11,11 @@ import (
 
 type ConfigYellowfin struct {
 	Enabled bool
+	// If this is true, then we store yellowfin cookies in the user's browser.
+	// If this is false, then we transparently login to Yellowfin via the Router.
+	// We could probably get rid of this old code path, but it adds minimal
+	// complexity to the code, and might still prove useful.
+	UseLegacyAuth bool
 }
 
 // Note: Be sure to keep doc.go up to date with the Config structure here


### PR DESCRIPTION
This is used by the Router to perform a transparent login to Yellowfin.