### PR TITLE
PCS-747: Auth notifications

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -11,19 +11,10 @@ import (
 	"strings"
 )
 
-const TestConfig1 = "!TESTCONFIG1"
-const TestPort = 3377
-
 // These files are written by create-keys.rb
 const (
 	YellowfinAdminPasswordFile = "c:/imqsvar/secrets/yellowfin_admin"
 	YellowfinUserPasswordFile  = "c:/imqsvar/secrets/yellowfin_user"
-)
-
-const (
-	// Hard-coded group names
-	RoleGroupAdmin   = "admin"
-	RoleGroupEnabled = "enabled"
 )
 
 func main() {
@@ -56,7 +47,7 @@ func main() {
 		"launch as a Windows Service. Otherwise, this runs in the foreground, and returns with an error code of 1. When running in the foreground, "+
 		"log messages are still sent to the logfile (not to the console).")
 
-	app.AddValueOption("c", "configfile", "Specify the imqsauth config file. A pseudo file called "+TestConfig1+" is "+
+	app.AddValueOption("c", "configfile", "Specify the imqsauth config file. A pseudo file called "+imqsauth.TestConfig1+" is "+
 		"used by the REST test suite to load a test configuration. This option is mandatory.")
 
 	app.AddBoolOption("nosvc", "Do not try to run as a Windows Service. Normally, the 'run' command detects whether this is an "+
@@ -99,7 +90,7 @@ func exec(cmdName string, args []string, options cli.OptionSet) {
 	}
 
 	// Try test config first; otherwise load real config
-	isTestConfig := loadTestConfig(ic, configFile)
+	isTestConfig := imqsauth.LoadTestConfig(ic, configFile)
 	if !isTestConfig {
 		if err := ic.Config.LoadFile(configFile); err != nil {
 			panic(fmt.Sprintf("Error loading config file '%v': %v", configFile, err))
@@ -163,7 +154,7 @@ func exec(cmdName string, args []string, options cli.OptionSet) {
 	case "permshow":
 		success = permShow(ic, 0, args[0])
 	case "resetauthgroups":
-		success = resetAuthGroups(ic)
+		success = imqsauth.ResetAuthGroups(ic)
 	case "run":
 		if options.Has("nosvc") || !authaus.RunAsService(handlerNoRetVal) {
 			success = false
@@ -193,34 +184,6 @@ func exec(cmdName string, args []string, options cli.OptionSet) {
 	}
 }
 
-func loadTestConfig(ic *imqsauth.ImqsCentral, testConfigName string) bool {
-	if testConfigName == TestConfig1 {
-		ic.Config.ResetForUnitTests()
-		ic.Config.Authaus.HTTP.Bind = "127.0.0.1"
-		ic.Config.Authaus.HTTP.Port = TestPort
-		ic.Central = authaus.NewCentralDummy("")
-		resetAuthGroups(ic)
-		ic.Central.CreateAuthenticatorIdentity("joe", "JOE")
-		ic.Central.CreateAuthenticatorIdentity("jack", "JACK")
-		ic.Central.CreateAuthenticatorIdentity("admin", "ADMIN")
-		ic.Central.CreateAuthenticatorIdentity("admin_disabled", "ADMIN_DISABLED")
-		groupAdmin, _ := ic.Central.GetRoleGroupDB().GetByName(RoleGroupAdmin)
-		groupEnabled, _ := ic.Central.GetRoleGroupDB().GetByName(RoleGroupEnabled)
-		permitEnabled := &authaus.Permit{}
-		permitEnabled.Roles = authaus.EncodePermit([]authaus.GroupIDU32{groupEnabled.ID})
-		permitAdminEnabled := &authaus.Permit{}
-		permitAdminEnabled.Roles = authaus.EncodePermit([]authaus.GroupIDU32{groupAdmin.ID, groupEnabled.ID})
-		permitAdminDisabled := &authaus.Permit{}
-		permitAdminDisabled.Roles = authaus.EncodePermit([]authaus.GroupIDU32{groupAdmin.ID})
-		ic.Central.SetPermit("joe", permitEnabled)
-		ic.Central.SetPermit("jack", permitEnabled)
-		ic.Central.SetPermit("admin", permitAdminEnabled)
-		ic.Central.SetPermit("admin_disabled", permitAdminDisabled)
-		return true
-	}
-	return false
-}
-
 func createDB(config *authaus.Config) (success bool) {
 	success = true
 	if err := authaus.SqlCreateSchema_User(&config.PermitDB.DB); err != nil {
@@ -245,16 +208,6 @@ func createDB(config *authaus.Config) (success bool) {
 	}
 
 	return success
-}
-
-func loadOrCreateGroup(icentral *imqsauth.ImqsCentral, groupName string, createIfNotExist bool) (*authaus.AuthGroup, error) {
-	if group, error := authaus.LoadOrCreateGroup(icentral.Central.GetRoleGroupDB(), groupName, createIfNotExist); error == nil {
-		fmt.Printf("Group %v created\n", groupName)
-		return group, nil
-	} else {
-		fmt.Printf("Error creating group %v, %v ", groupName, error)
-		return nil, error
-	}
 }
 
 func resetGroup(icentral *imqsauth.ImqsCentral, group *authaus.AuthGroup) bool {
@@ -419,7 +372,7 @@ func setGroup(icentral *imqsauth.ImqsCentral, groupName string, roles []string) 
 		}
 	}
 
-	return modifyGroup(icentral, groupModifySet, groupName, perms)
+	return imqsauth.ModifyGroup(icentral, imqsauth.GroupModifySet, groupName, perms)
 }
 
 func createUser(icentral *imqsauth.ImqsCentral, options map[string]string, identity string, password string) bool {
@@ -485,62 +438,4 @@ func resetPassword(icentral *imqsauth.ImqsCentral, identity string) bool {
 		fmt.Printf("Error %v %v\n", code, msg)
 		return false
 	}
-}
-
-type groupModifyMode int
-
-const (
-	groupModifySet groupModifyMode = iota
-	groupModifyAdd
-	groupModifyRemove
-)
-
-func saveGroup(icentral *imqsauth.ImqsCentral, group *authaus.AuthGroup) bool {
-	if err := icentral.Central.GetRoleGroupDB().UpdateGroup(group); err == nil {
-		fmt.Printf("Group %v updated\n", group.Name)
-		return true
-	} else {
-		fmt.Printf("Error updating group of %v: %v\n", group.Name, err)
-		return false
-	}
-}
-
-func modifyGroup(icentral *imqsauth.ImqsCentral, mode groupModifyMode, groupName string, perms authaus.PermissionList) bool {
-	if group, e := loadOrCreateGroup(icentral, groupName, true); e == nil {
-		switch mode {
-		case groupModifyAdd:
-			for _, perm := range perms {
-				group.AddPerm(perm)
-			}
-		case groupModifyRemove:
-			for _, perm := range perms {
-				group.RemovePerm(perm)
-			}
-		case groupModifySet:
-			group.PermList = make(authaus.PermissionList, len(perms))
-			copy(group.PermList, perms)
-		default:
-			panic(fmt.Sprintf("Unrecognized permission set mode %v", mode))
-		}
-		if saveGroup(icentral, group) {
-			return true
-		} else {
-			return false
-		}
-	} else {
-		fmt.Printf("Error retrieving group '%v': %v\n", groupName, e)
-		return false
-	}
-}
-
-// Reset auth groups to a sane state. After running this, you should be able to use
-// the web interface to do everything else. That's the idea at least (the web interface has yet to be built).
-func resetAuthGroups(icentral *imqsauth.ImqsCentral) bool {
-	ok := true
-	ok = ok && modifyGroup(icentral, groupModifySet, RoleGroupAdmin, authaus.PermissionList{imqsauth.PermAdmin})
-	ok = ok && modifyGroup(icentral, groupModifySet, RoleGroupEnabled, authaus.PermissionList{imqsauth.PermEnabled})
-	if !ok {
-		return false
-	}
-	return true
 }

--- a/imqsauth/all_test.go
+++ b/imqsauth/all_test.go
@@ -1,10 +1,152 @@
 package imqsauth
 
 import (
+	"fmt"
+	"golang.org/x/net/websocket"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
 	"testing"
+	"time"
 )
 
-// This might be the appropriate place for REST API tests
-// At present, REST tests are run from the ruby script resttest.rb
-func TestEmpty(t *testing.T) {
+const origin = "http://localhost/"
+const originHttpUrl = "http://localhost:3377"
+
+// At present, most of the HTTP API tests are performed in the ruby script "resttest.rb".
+// The Web Socket tests are the only HTTP tests performed here. It might be prudent to move
+// the ruby-based tests in here too, provided one could keep the number of lines of code similar.
+
+// NOTE: If you add ANY MORE tests here that use an actual HTTP server, then you're going to
+// have to work around the fact that as of right now (Go 1.6) there is no way to gracefully
+// stop a net/http Server. The only plausible thing I can think of is to keep the same server
+// running for all tests. This is tricky, because you really want the server to start with
+// a clean slate each time. However, it shouldn't be hard to add a 'resetForTest' function
+// to ImqsCentral.
+// This issue is tracked by https://github.com/golang/go/issues/4674. Take a look and see if
+// that has been resolved in subsequent (post 1.6) versions of Go.
+
+func TestWebSocket(t *testing.T) {
+	// start server
+	go func() {
+		ic := &ImqsCentral{}
+		ic.Config = &Config{}
+		LoadTestConfig(ic, TestConfig1)
+		ic.RunHttp()
+	}()
+
+	const wsUrl = "ws://localhost:3377/notifications"
+
+	cookie, err := login()
+	if err != nil {
+		t.Fatalf("Login failed: %v", err)
+	}
+
+	// websocket with auth
+	ws, err := createWebSocketAndConnect(wsUrl, origin, cookie)
+	if err != nil {
+		t.Fatalf("createWebSocketAndConnect (authorized) failed: %v", err)
+	}
+
+	// websocket without auth
+	wsUnauthorized, err := createWebSocketAndConnect(wsUrl, origin, "")
+	if err != nil {
+		t.Fatalf("createWebSocketAndConnect (unauthorized) failed: %v", err)
+	}
+
+	// Ensure that our unauthorized websocket connection doesn't work.
+	msg := ""
+	if err := websocket.Message.Receive(wsUnauthorized, &msg); err != io.EOF {
+		t.Fatalf("Expected to receieve ie.EOF error from unauthorized websocket, but instead got '%v'", err)
+	}
+
+	wsExpectNothing(t, ws)
+	doRequestExpectOK(t, "PUT", originHttpUrl+"/create_user?identity=socketuser&password=socketuser", cookie)
+	doRequestExpectOK(t, "PUT", originHttpUrl+"/create_group?groupname=socketusergroup", cookie)
+	doRequestExpectOK(t, "POST", originHttpUrl+"/set_user_groups?identity=socketuser&groups=enabled,socketusergroup", cookie)
+	// expect to receive a message because set_user_groups affects us
+	wsExpect(t, ws, "auth:permissions_changed:socketuser")
+	wsExpectNothing(t, ws)
+}
+
+func doRequest(verb, url, cookie string) (*http.Response, error) {
+	request, err := http.NewRequest(verb, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if cookie != "" {
+		request.Header.Add("Cookie", cookie)
+	}
+	return http.DefaultClient.Do(request)
+}
+
+func doRequestExpectOK(t *testing.T, verb, url, cookie string) *http.Response {
+	response, err := doRequest(verb, url, cookie)
+	if err != nil || response.StatusCode != 200 {
+		t.Fatalf("Unexpected response from %v %v: %v %v", verb, url, response.Status, err)
+	}
+	return response
+}
+
+func wsExpect(t *testing.T, ws *websocket.Conn, expect string) {
+	ws.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	msg := ""
+	if err := websocket.Message.Receive(ws, &msg); err != nil {
+		t.Fatalf("Error receiving on websocket: %v", err)
+	}
+	if msg != expect {
+		t.Fatalf("Incorrect value received on websocket:\nExpected: %v\nActual:   %v", expect, msg)
+	}
+}
+
+func wsExpectNothing(t *testing.T, ws *websocket.Conn) {
+	ws.SetReadDeadline(time.Now().Add(time.Millisecond))
+	msg := ""
+	if err := websocket.Message.Receive(ws, &msg); strings.Index(err.Error(), "i/o timeout") == -1 {
+		t.Fatalf("Expected websocket to be silent, but instead got '%v' (msg = '%v')", err, msg)
+	}
+}
+
+// Returns (Set-Cookie header, error)
+func login() (string, error) {
+	request, err := http.NewRequest("POST", originHttpUrl+"/login", nil)
+	if err != nil {
+		return "", err
+	}
+
+	request.SetBasicAuth("admin", "ADMIN")
+	resp, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode == 200 {
+		return resp.Header.Get("Set-Cookie"), nil
+	} else {
+		return "", nil
+	}
+}
+
+func createWebSocketAndConnect(wsUrlLocal string, wsOriginLocal string, cookie string) (*websocket.Conn, error) {
+	wsUrlObject, err := url.Parse(wsUrlLocal)
+	if err != nil {
+		return nil, fmt.Errorf("Could not construct ws url: %v", err)
+	}
+
+	originUrlObject, err := url.Parse(wsOriginLocal)
+	if err != nil {
+		return nil, fmt.Errorf("Could not construct origin url: %v", err)
+	}
+
+	headers := http.Header{}
+	headers.Add("Cookie", cookie)
+
+	config := websocket.Config{
+		Location: wsUrlObject,
+		Origin:   originUrlObject,
+		Version:  websocket.ProtocolVersionHybi13,
+		Header:   headers,
+	}
+	ws, err := websocket.DialConfig(&config)
+	return ws, err
 }

--- a/imqsauth/groups.go
+++ b/imqsauth/groups.go
@@ -1,0 +1,80 @@
+package imqsauth
+
+import (
+	"fmt"
+	"github.com/IMQS/authaus"
+)
+
+const (
+	// Hard-coded group names
+	RoleGroupAdmin   = "admin"
+	RoleGroupEnabled = "enabled"
+)
+
+// Reset auth groups to a sane state. After running this, you should be able to use
+// the web interface to do everything else. That's the idea at least (the web interface has yet to be built).
+func ResetAuthGroups(icentral *ImqsCentral) bool {
+	ok := true
+	ok = ok && ModifyGroup(icentral, GroupModifySet, RoleGroupAdmin, authaus.PermissionList{PermAdmin})
+	ok = ok && ModifyGroup(icentral, GroupModifySet, RoleGroupEnabled, authaus.PermissionList{PermEnabled})
+	if !ok {
+		return false
+	}
+	return true
+}
+
+func ModifyGroup(icentral *ImqsCentral, mode GroupModifyMode, groupName string, perms authaus.PermissionList) bool {
+	if group, e := loadOrCreateGroup(icentral, groupName, true); e == nil {
+		switch mode {
+		case GroupModifyAdd:
+			for _, perm := range perms {
+				group.AddPerm(perm)
+			}
+		case GroupModifyRemove:
+			for _, perm := range perms {
+				group.RemovePerm(perm)
+			}
+		case GroupModifySet:
+			group.PermList = make(authaus.PermissionList, len(perms))
+			copy(group.PermList, perms)
+		default:
+			panic(fmt.Sprintf("Unrecognized permission set mode %v", mode))
+		}
+		if saveGroup(icentral, group) {
+			return true
+		} else {
+			return false
+		}
+	} else {
+		fmt.Printf("Error retrieving group '%v': %v\n", groupName, e)
+		return false
+	}
+}
+
+type GroupModifyMode int
+
+const (
+	GroupModifySet GroupModifyMode = iota
+	GroupModifyAdd
+	GroupModifyRemove
+)
+
+func saveGroup(icentral *ImqsCentral, group *authaus.AuthGroup) bool {
+	if err := icentral.Central.GetRoleGroupDB().UpdateGroup(group); err == nil {
+		fmt.Printf("Group %v updated\n", group.Name)
+		return true
+	} else {
+		fmt.Printf("Error updating group of %v: %v\n", group.Name, err)
+		return false
+	}
+}
+
+func loadOrCreateGroup(icentral *ImqsCentral, groupName string, createIfNotExist bool) (*authaus.AuthGroup, error) {
+	if group, error := authaus.LoadOrCreateGroup(icentral.Central.GetRoleGroupDB(), groupName, createIfNotExist); error == nil {
+		fmt.Printf("Group %v created\n", groupName)
+		return group, nil
+	} else {
+		fmt.Printf("Error creating group %v, %v ", groupName, error)
+		return nil, error
+	}
+}

--- a/imqsauth/test_tools.go
+++ b/imqsauth/test_tools.go
@@ -1,0 +1,36 @@
+package imqsauth
+
+import (
+	"github.com/IMQS/authaus"
+)
+
+const TestConfig1 = "!TESTCONFIG1"
+const TestPort = 3377
+
+func LoadTestConfig(ic *ImqsCentral, testConfigName string) bool {
+	if testConfigName == TestConfig1 {
+		ic.Config.ResetForUnitTests()
+		ic.Config.Authaus.HTTP.Bind = "127.0.0.1"
+		ic.Config.Authaus.HTTP.Port = TestPort
+		ic.Central = authaus.NewCentralDummy("")
+		ResetAuthGroups(ic)
+		ic.Central.CreateAuthenticatorIdentity("joe", "JOE")
+		ic.Central.CreateAuthenticatorIdentity("jack", "JACK")
+		ic.Central.CreateAuthenticatorIdentity("admin", "ADMIN")
+		ic.Central.CreateAuthenticatorIdentity("admin_disabled", "ADMIN_DISABLED")
+		groupAdmin, _ := ic.Central.GetRoleGroupDB().GetByName(RoleGroupAdmin)
+		groupEnabled, _ := ic.Central.GetRoleGroupDB().GetByName(RoleGroupEnabled)
+		permitEnabled := &authaus.Permit{}
+		permitEnabled.Roles = authaus.EncodePermit([]authaus.GroupIDU32{groupEnabled.ID})
+		permitAdminEnabled := &authaus.Permit{}
+		permitAdminEnabled.Roles = authaus.EncodePermit([]authaus.GroupIDU32{groupAdmin.ID, groupEnabled.ID})
+		permitAdminDisabled := &authaus.Permit{}
+		permitAdminDisabled.Roles = authaus.EncodePermit([]authaus.GroupIDU32{groupAdmin.ID})
+		ic.Central.SetPermit("joe", permitEnabled)
+		ic.Central.SetPermit("jack", permitEnabled)
+		ic.Central.SetPermit("admin", permitAdminEnabled)
+		ic.Central.SetPermit("admin_disabled", permitAdminDisabled)
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Trigger on group permissions changes, compile affected identities list
Trigger on user group affiliation
No message if no user identities affected by group change
SendAll broadcast function
No broadcast on explicit logout endpoints
Web socket auth implemented (headers forwarded by router)
Web socket test (resttest.rb and all_test.go)

**Please note, you need to checkout this branch on all of the following repositories:**
auth
imqsauth
router
router-core
www
static-conf