### PR TITLE
dont log out YF if no cookie

### DIFF
--- a/imqsauth/http.go
+++ b/imqsauth/http.go
@@ -438,8 +438,11 @@ func httpHandlerLogout(central *ImqsCentral, w http.ResponseWriter, r *httpReque
 		return
 	}
 
-	if err := central.Yellowfin.Logout(identity, r.http); err != nil {
-		central.Central.Log.Errorf("Yellowfin logout error: %v", err)
+	// Only attempt YF logout if its cookie (JSESSIONID) is present in the logout call
+	if _, err := r.http.Cookie("JSESSIONID"); err == nil {
+		if err := central.Yellowfin.Logout(identity, r.http); err != nil {
+			central.Central.Log.Errorf("Yellowfin logout error: %v", err)
+		}
 	}
 	authaus.HttpSendTxt(w, http.StatusOK, "")
 }


### PR DESCRIPTION
Please review

We should not attempt to logout YF when we do not receive a cookie for it in the call. TI-1331

There is another bug, the router should inject the cookie upon logout as the browser does not store it anymore. After the router sends the logout request to the auth system it should delete the YF cookie.