### PR TITLE
Move Audit to serviceauth and remove cmode flag

### DIFF
--- a/imqsauth/audit.go
+++ b/imqsauth/audit.go
@@ -1,67 +1,21 @@
 package imqsauth
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-	"time"
-
 	"github.com/IMQS/log"
 	"github.com/IMQS/serviceauth"
 )
 
 type IMQSAuditor struct {
-	Url string
 	Log *log.Logger
 }
 
-func NewIMQSAuditor(url string, logger *log.Logger) *IMQSAuditor {
-	return &IMQSAuditor{Url: url, Log: logger}
-}
-
-type Action struct {
-	Who     string        `json:"who"`
-	DidWhat string        `json:"did_what"`
-	ToWhat  string        `json:"to_what"`
-	AtTime  int64         `json:"at_time"`
-	Context ActionContext `json:"context"`
-}
-
-type ActionContext struct {
-	Location string `json:"location"`
+func NewIMQSAuditor(logger *log.Logger) *IMQSAuditor {
+	return &IMQSAuditor{Log: logger}
 }
 
 func (a *IMQSAuditor) AuditUserAction(identity, clientIp, description string) {
-	action := &Action{Who: identity, DidWhat: description, AtTime: time.Now().Unix()}
-	action.Context.Location = clientIp
-
-	jsonBuf := new(bytes.Buffer)
-	encoder := json.NewEncoder(jsonBuf)
-	err := encoder.Encode(action)
+	err := serviceauth.AddToAuditLogServiceToService(identity, clientIp, description)
 	if err != nil {
-		a.Log.Errorf("Failed to marshal action into json: (%v)", err)
-		return
+		a.Log.Errorf("%v", err)
 	}
-
-	req, err := http.NewRequest("POST", a.Url, jsonBuf)
-	if err != nil {
-		a.Log.Errorf("Error creating audit request: (%v)", err)
-		return
-	}
-	// Override RFC1123 format to print out GMT instead of UTC as required by serviceauth package.
-	req.Header.Add("Date", time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 GMT"))
-	req.Header.Set("Content-Type", "application/json")
-
-	err = serviceauth.CreateInterServiceRequest(req, jsonBuf.Bytes())
-	if err != nil {
-		a.Log.Errorf("Error creating audit interservice request: (%v)", err)
-		return
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		a.Log.Errorf("Error calling audit service: (%v)", err)
-		return
-	}
-	resp.Body.Close()
 }

--- a/imqsauth/config.go
+++ b/imqsauth/config.go
@@ -1,17 +1,18 @@
 package imqsauth
 
 import (
-	"github.com/IMQS/authaus"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
+
+	"github.com/IMQS/authaus"
 	"github.com/IMQS/serviceconfigsgo"
 )
 
 const (
-	serviceConfigFileName                        = "imqsauth.json"
-	serviceConfigVersion                         = 1
-	serviceName                                  = "ImqsAuth"
+	serviceConfigFileName = "imqsauth.json"
+	serviceConfigVersion  = 1
+	serviceName           = "ImqsAuth"
 )
 
 type ConfigYellowfin struct {
@@ -42,7 +43,6 @@ type Config struct {
 	lastFileLoaded             string // Used for relative paths (such as HostnameFile)
 	enablePcsRename            bool   // Disabled by unit tests
 	NotificationUrl            string
-	AuditServiceUrl            string
 }
 
 func (x *Config) Reset() {
@@ -59,9 +59,9 @@ func (x *Config) ResetForUnitTests() {
 	x.enablePcsRename = false
 }
 
-func (x *Config) LoadFile(filename string, cMode bool) error {
+func (x *Config) LoadFile(filename string) error {
 	x.Reset()
-	err := serviceconfig.GetConfig(filename, serviceName, serviceConfigVersion, serviceConfigFileName, x, cMode)
+	err := serviceconfig.GetConfig(filename, serviceName, serviceConfigVersion, serviceConfigFileName, x)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Moved the audit user functionality to the serviceauth repo so that other
service can make use of it if required. Also it was decided to use an
environment variable to determine if the service is running inside a
container which is placed in serviceconfigs so the command line variable
d for the cmode is removed