### PR TITLE
Enhance audit log message for Group Perm updates

### DIFF
--- a/auth/all_test.go
+++ b/auth/all_test.go
@@ -88,6 +88,10 @@ func TestDistributerPost(t *testing.T) {
 	// Change a group, which sends a POST to the distributor service
 	doRequestExpectOK(t, "PUT", originHttpUrl+"/create_group?groupname=socketusergroup", cookie)
 	doRequestExpectOK(t, "POST", fmt.Sprintf("%v/set_user_groups?userid=%v&groups=enabled,socketusergroup", originHttpUrl, joeUserId), cookie)
+	doRequestExpectResponse(t, "PUT", originHttpUrl+"/set_group_roles?groupname=socketusergroup&roles=1", cookie,
+		"Group: socketusergroup roles updated: Added: admin Removed:")
+	doRequestExpectResponse(t, "PUT", originHttpUrl+"/set_group_roles?groupname=socketusergroup&roles=2,3", cookie,
+		"Group: socketusergroup roles updated: Added: enabled pcsmoduleaccess Removed: admin")
 }
 
 func doRequest(verb, url, cookie string) (*http.Response, error) {
@@ -105,6 +109,20 @@ func doRequestExpectOK(t *testing.T, verb, url, cookie string) *http.Response {
 	response, err := doRequest(verb, url, cookie)
 	if err != nil || response.StatusCode != 200 {
 		t.Fatalf("Unexpected response from %v %v: %v %v", verb, url, response.Status, err)
+	}
+	return response
+}
+
+func doRequestExpectResponse(t *testing.T, verb, url, cookie string, responseText string) *http.Response {
+	response, err := doRequest(verb, url, cookie)
+	if err != nil || response.StatusCode != 200 {
+		t.Fatalf("Expected OK")
+	} else {
+		body, err := ioutil.ReadAll(response.Body)
+		txt := string(body[:])
+		if txt != responseText {
+			t.Fatalf("Unexpected response from %v %v: %v %v %v", verb, url, response.Status, err, txt)
+		}
 	}
 	return response
 }

--- a/auth/http.go
+++ b/auth/http.go
@@ -1077,16 +1077,16 @@ func httpHandlerSetGroupRoles(central *ImqsCentral, w http.ResponseWriter, r *ht
 		central.Central.Log.Infof("Roles %v set for group %v", rolesstring, groupname)
 		existingPerms := group.PermList
 
-		removed := Diff(existingPerms, newPerms)
-		added := Diff(newPerms, existingPerms)
+		removed := existingPerms.Diff(&newPerms)
+		added := newPerms.Diff(&existingPerms)
 
 		// Convert to real names
 		changednames := "Added:"
-		for _, e := range added {
+		for _, e := range *added {
 			changednames += " " + PermissionsTable[e]
 		}
 		changednames += " Removed:"
-		for _, e := range removed {
+		for _, e := range *removed {
 			changednames += " " + PermissionsTable[e]
 		}
 		description := ""
@@ -1115,23 +1115,6 @@ func httpHandlerSetGroupRoles(central *ImqsCentral, w http.ResponseWriter, r *ht
 	}
 
 	broadcastGroupChange(central, r, groupname)
-}
-
-func Diff(a authaus.PermissionList, b authaus.PermissionList) authaus.PermissionList {
-	d := authaus.PermissionList{}
-	for _, ep := range a {
-		found := false
-		for _, np := range b {
-			if ep == np {
-				found = true
-				break
-			}
-		}
-		if !found {
-			d = append(d, ep)
-		}
-	}
-	return d
 }
 
 func broadcastGroupChange(central *ImqsCentral, r *httpRequest, groupname string) {

--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
+
+replace (
+	github.com/IMQS/authaus v1.0.20 => "../authaus/"
+)


### PR DESCRIPTION
Include the actual permission names added / removed for the group in the audit message.