### PR TITLE
BAZ-202 : Fix passthrough auth session bug.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ imqsauth
 test-output
 Dockerfile-gotest
 __debug_bin
+/imqsauth.exe

--- a/go.mod
+++ b/go.mod
@@ -21,3 +21,5 @@ require (
 	golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e // indirect
 	golang.org/x/sys v0.0.0-20211111213525-f221eed1c01e // indirect
 )
+
+replace github.com/IMQS/authaus v1.0.25 => "../authaus"


### PR DESCRIPTION
Passthrough auth never created oauth sessions since it relied on entries in oauthchallenge. It appeared to work for a while after login because there were normal sessions created in authsession.

Marking as "draft" until the authaus PR has been approved and version updated.