### PR TITLE
feat(mail): Specifying template and from

### DIFF
--- a/auth/config.go
+++ b/auth/config.go
@@ -15,7 +15,24 @@ const (
 	serviceConfigFileName = "imqsauth.json"
 	serviceConfigVersion  = 1
 	serviceName           = "ImqsAuth"
+	defaultMailerURL      = "https://imqs-mailer.appspot.com"
 )
+
+type MailParameters struct {
+	// Name of the template that the mail server should use when generating the
+	// email body. Optional.
+	TemplateName *string `json:"template_name,omitempty"`
+	// Custom from variable to be used by mailer service. Optional
+	// eg: IMQS Password Reset <noreply@imqs.co.za>
+	From *string `json:"from,omitempty"`
+}
+
+type SendMailDetails struct {
+	// URL of mail server. Optional.
+	URL           *string         `json:"url,omitempty"`
+	PasswordReset *MailParameters `json:"password_reset,omitempty"`
+	NewAccount    *MailParameters `json:"new_account,omitempty"`
+}
 
 // Permission holds all of the details to create the dynamic permission list.
 // These permissions are used for code implementations which are purely driven
@@ -26,19 +43,20 @@ const (
 // to match specific client requirements.
 // Client/dynamic permissions are added to the imqsauth.json file using the following
 // as an example:
-// {
-// 	"Permissions": {
-// 		"dynamic": [
-// 			{"id": "15000", "name": "MMTest", "friendly": "An MM Test Permission",
-//			"description": "MM Test permission", "module": "Maintenance Management"}
-// 		],
-//		"disable": ["newMmIlCreateAdd"],
-//		"relabel": [
-//			{"id": "1204", "name": "newMmIlArchive", "friendly": "Archive incident",
-//			"description": "MM Acrhive an incident", "module": "Maintenance Management"}
-//		]
-// 	}
-// }
+//
+//	{
+//		"Permissions": {
+//			"dynamic": [
+//				{"id": "15000", "name": "MMTest", "friendly": "An MM Test Permission",
+//				"description": "MM Test permission", "module": "Maintenance Management"}
+//			],
+//			"disable": ["newMmIlCreateAdd"],
+//			"relabel": [
+//				{"id": "1204", "name": "newMmIlArchive", "friendly": "Archive incident",
+//				"description": "MM Acrhive an incident", "module": "Maintenance Management"}
+//			]
+//		}
+//	}
 type Permission struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
@@ -62,6 +80,7 @@ type Config struct {
 	PasswordResetExpirySeconds float64
 	NewAccountExpirySeconds    float64
 	SendMailPassword           string // NB: When moving SendMailPassword to a standalone secrets file, change for PCS also. PCS reads imqsauth config file.
+	SendMailDetails            SendMailDetails
 	NotificationUrl            string
 	hostname                   string // This is read from environment variable the first time GetHostname is called
 	lastFileLoaded             string // Used for relative paths (such as HostnameFile)
@@ -69,8 +88,20 @@ type Config struct {
 	Permissions                *ManagePermissions
 }
 
+func (x *SendMailDetails) SetDefaults() {
+	if x.URL == nil {
+		u := defaultMailerURL
+		x.URL = &u
+	}
+}
+
+func (x *Config) SetDefaults() {
+	x.SendMailDetails.SetDefaults()
+}
+
 func (x *Config) Reset() {
 	*x = Config{}
+	x.SetDefaults()
 	x.PasswordResetExpirySeconds = 24 * 3600
 	x.NewAccountExpirySeconds = 5 * 365 * 24 * 3600
 	x.enablePcsRename = true
@@ -89,9 +120,11 @@ func (x *Config) LoadFile(filename string) error {
 	if err != nil {
 		return err
 	}
+
+	x.SetDefaults()
+
 	x.lastFileLoaded = filename
-	err = x.loadDynamicPermissions()
-	return err
+	return x.loadDynamicPermissions()
 }
 
 // loadDynamicPermissions adds the dynamic permissions from config to the

--- a/auth/config.go
+++ b/auth/config.go
@@ -21,17 +21,17 @@ const (
 type MailParameters struct {
 	// Name of the template that the mail server should use when generating the
 	// email body. Optional.
-	TemplateName *string `json:"template_name,omitempty"`
+	TemplateName *string `json:"TemplateName,omitempty"`
 	// Custom from variable to be used by mailer service. Optional
 	// eg: IMQS Password Reset <noreply@imqs.co.za>
-	From *string `json:"from,omitempty"`
+	From *string `json:"From,omitempty"`
 }
 
 type SendMailDetails struct {
 	// URL of mail server. Optional.
-	URL           *string         `json:"url,omitempty"`
-	PasswordReset *MailParameters `json:"password_reset,omitempty"`
-	NewAccount    *MailParameters `json:"new_account,omitempty"`
+	URL           *string         `json:"URL,omitempty"`
+	PasswordReset *MailParameters `json:"PasswordReset,omitempty"`
+	NewAccount    *MailParameters `json:"NewAccount,omitempty"`
 }
 
 // Permission holds all of the details to create the dynamic permission list.

--- a/auth/doc.go
+++ b/auth/doc.go
@@ -11,11 +11,22 @@ system to accomodate that kind of thing.
 
 Example config file:
 
-{
-	"Authaus": {...},								-- See config.go in Authaus package for description of the Authaus config
-	"PasswordResetExpirySeconds": 3600,
-	"HostnameFile": "hostname",						-- Relative to the location of imqsauthconfig.json, or an absolute path
-	"SendMailPassword": "password123"
-}
+	{
+		"Authaus": {...},								-- See config.go in Authaus package for description of the Authaus config
+		"PasswordResetExpirySeconds": 3600,
+		"HostnameFile": "hostname",						-- Relative to the location of imqsauthconfig.json, or an absolute path
+		"SendMailPassword": "password123",
+		"SendMailDetails": {
+			"URL": "https://imqs-mailer.appspot.com",
+			"PasswordReset": {
+				"TemplateName": "skypipe-inc-reset-password",							-- See https://github.com/IMQS/imqs-mailer#api for more info on valid templates
+				"From": "SkyPipe Inc. Password Reset <noreply@skypipeinc.com>"
+			},
+			"NewAccount": {
+				"TemplateName": "skypipe-inc-new-account-confirm",						-- See https://github.com/IMQS/imqs-mailer#api for more info on valid templates
+				"From": "SkyPipe Inc. Account Confirmation <noreply@skypipeinc.com>"
+			}
+		}
+	}
 */
 package imqsauth

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.2.0
+## Current
 
 * feat(mail): Adds new config to send custom `from` and specify a template to be
 used as an email body when resetting a password, or confirming a new account.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 * feat(mail): Adds new config to send custom `from` and specify a template to be
 used as an email body when resetting a password, or confirming a new account.
-The URL for mailer has also been made configurable.
+The URL for mailer has also been made configurable. (ASG-2630)
 
 ## v1.1.2
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.0
+
+* feat(mail): Adds new config to send custom `from` and specify a template to be
+used as an email body when resetting a password, or confirming a new account.
+The URL for mailer has also been made configurable.
+
 ## v1.1.2
 
 * fix: Update authaus version. (ASG-2622)


### PR DESCRIPTION
Adds support for new optional query parameters on `passwordReset` endpoint on mailer.

Adds new config variable `SendMailDetails`, which contains the URL of the mailer service and parameters for the new query parameters on mailer. Password resets and new account parameters are stored separately.

Refs: ASG-2630

# Note

~~I still need to update doc.go~~