### PR TITLE
feat(mail): Custom from and subject for LDAP reset

### DIFF
--- a/auth/config.go
+++ b/auth/config.go
@@ -25,6 +25,9 @@ type MailParameters struct {
 	// Custom from variable to be used by mailer service. Optional
 	// eg: IMQS Password Reset <noreply@imqs.co.za>
 	From *string `json:"From,omitempty"`
+	// Custom subject variable to be used by mailer service. Optional
+	// eg: IMQS Reset Password
+	Subject *string `json:"Subject,omitempty"`
 }
 
 type SendMailDetails struct {
@@ -32,6 +35,8 @@ type SendMailDetails struct {
 	URL           *string         `json:"URL,omitempty"`
 	PasswordReset *MailParameters `json:"PasswordReset,omitempty"`
 	NewAccount    *MailParameters `json:"NewAccount,omitempty"`
+	// Currently does not make use of `TemplateName`
+	LDAPPasswordReset *MailParameters `json:"LDAPPasswordReset,omitempty"`
 }
 
 // Permission holds all of the details to create the dynamic permission list.

--- a/auth/doc.go
+++ b/auth/doc.go
@@ -25,6 +25,10 @@ Example config file:
 			"NewAccount": {
 				"TemplateName": "skypipe-inc-new-account-confirm",						-- See https://github.com/IMQS/imqs-mailer#api for more info on valid templates
 				"From": "SkyPipe Inc. Account Confirmation <noreply@skypipeinc.com>"
+			},
+			"LDAPPasswordReset": {
+				"From": "SkyPipe Inc. Password Reset <noreply@skypipeinc.com>",
+				"Subject": "SkyPipe Inc. Reset Password"
 			}
 		}
 	}

--- a/auth/http.go
+++ b/auth/http.go
@@ -395,8 +395,27 @@ func (x *ImqsCentral) createDefaultMailQuery(user authaus.AuthUser, token string
 func (x *ImqsCentral) createLDAPMailQueryAndBody(user authaus.AuthUser) (string, string) {
 	var mailQuery string
 	var mailBody string
+
 	mailQuery += "sendEmail?"
-	mailQuery += fmt.Sprintf("emailTo=%v&subject=%v&ishtml=True", url.QueryEscape(user.Email), url.QueryEscape("IMQS Reset Password"))
+	mailQuery += fmt.Sprintf("emailTo=%v&ishtml=True", url.QueryEscape(user.Email))
+
+	subject := "IMQS Reset Password"
+
+	// Handle optional overrides
+	if x.Config.SendMailDetails.LDAPPasswordReset != nil {
+		params := x.Config.SendMailDetails.LDAPPasswordReset
+
+		if params.Subject != nil {
+			subject = *params.Subject
+		}
+
+		if params.From != nil {
+			mailQuery += "&from=" + url.QueryEscape(*params.From)
+		}
+	}
+
+	mailQuery += "&subject=" + url.QueryEscape(subject)
+
 	if len(x.Config.Authaus.LDAP.SysAdminEmail) > 0 {
 		mailBody += fmt.Sprintf("This is an automated response.<br><br>To reset your password, please contact your System Administrator (%v).", x.Config.Authaus.LDAP.SysAdminEmail)
 	} else {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## Current
 
+* feat(mail): Adds new config to send custom `from` and `subject` for LDAP reset
+password emails.
 * feat(mail): Adds new config to send custom `from` and specify a template to be
 used as an email body when resetting a password, or confirming a new account.
 The URL for mailer has also been made configurable. (ASG-2630)


### PR DESCRIPTION
Adds new config to send custom `from` and `subject` for LDAP reset password emails.

Refs: ASG-2637

# NB

Needs to be merged to master after https://github.com/IMQS/imqsauth/pull/86 has been merged.