### PR TITLE
docs(api): reset_password_start->SendMailDetails.

### DIFF
--- a/docs/API/reset_password_start.md
+++ b/docs/API/reset_password_start.md
@@ -5,7 +5,7 @@ TODO: Summary
 ## Query Parameters
 
 | Param  | Description                                       |
-|--------|---------------------------------------------------|
+| ------ | ------------------------------------------------- |
 | userid | id of the user that needs their password reset    |
 | email  | email of the user that needs their password reset |
 

--- a/docs/API/reset_password_start.md
+++ b/docs/API/reset_password_start.md
@@ -5,9 +5,9 @@ TODO: Summary
 ## Query Parameters
 
 | Param  | Description                                       |
-| ------ | ------------------------------------------------- |
+|--------|---------------------------------------------------|
 | userid | id of the user that needs their password reset    |
-| email  | email of the user that needs thier password reset |
+| email  | email of the user that needs their password reset |
 
 ## Authaus
 

--- a/docs/API/reset_password_start.md
+++ b/docs/API/reset_password_start.md
@@ -1,0 +1,66 @@
+# POST /reset_password_start
+
+TODO: Summary
+
+## Query Parameters
+
+| Param  | Description                                       |
+| ------ | ------------------------------------------------- |
+| userid | id of the user that needs their password reset    |
+| email  | email of the user that needs thier password reset |
+
+## Authaus
+
+TODO: Talk about our interaction with authaus, and include links to authaus
+documentation on the functions we make use of.
+
+# Structs
+
+## MailParameters
+
+```go
+type MailParameters struct {
+	// Name of the template that the mail server should use when generating the
+	// email body. Optional.
+	TemplateName *string `json:"TemplateName,omitempty"`
+	// Custom from variable to be used by mailer service. Optional
+	// eg: IMQS Password Reset <noreply@imqs.co.za>
+	From *string `json:"From,omitempty"`
+}
+```
+
+## SendMailDetails
+
+```go
+type SendMailDetails struct {
+	// URL of mail server. Optional.
+	URL           *string         `json:"URL,omitempty"`
+	PasswordReset *MailParameters `json:"PasswordReset,omitempty"`
+	NewAccount    *MailParameters `json:"NewAccount,omitempty"`
+}
+```
+
+Refer to [MailParameters](#mailparameters) for more info on `PasswordReset` and
+`NewAccount`.
+
+# Config
+
+Example config:
+```json
+{
+	"SendMailDetails": {
+		"URL": "https://imqs-mailer.appspot.com",
+		"PasswordReset": {
+			"TemplateName": "skypipe-inc-reset-password",							// See https://github.com/IMQS/imqs-mailer#api for more info on valid templates
+			"From": "SkyPipe Inc. Password Reset <noreply@skypipeinc.com>"
+		},
+		"NewAccount": {
+			"TemplateName": "skypipe-inc-new-account-confirm",						// See https://github.com/IMQS/imqs-mailer#api for more info on valid templates
+			"From": "SkyPipe Inc. Account Confirmation <noreply@skypipeinc.com>"
+		}
+	}
+}
+```
+
+Refer to [SendMailDetails](#sendmaildetails) for more info on each of its
+variables.

--- a/docs/config-schema/imqsauth.json
+++ b/docs/config-schema/imqsauth.json
@@ -310,6 +310,21 @@
 		"SendMailPassword": {
 			"type": "string"
 		},
+		"SendMailDetails": {
+			"type": "object",
+			"properties": {
+				"URL": {
+					"type": "string",
+					"description": "URL of mail server."
+				},
+				"PasswordReset": {
+					"$ref": "#/defs/MailParameters"
+				},
+				"NewAccount": {
+					"$ref": "#/defs/MailParameters"
+				}
+			}
+		},
 		"NotificationUrl": {
 			"type": "string"
 		},
@@ -320,5 +335,20 @@
 	"required": [
 		"Authaus",
 		"Permissions"
-	]
+	],
+	"defs": {
+		"MailParameters": {
+			"type": "object",
+			"properties": {
+				"TemplateName": {
+					"type": "string",
+					"description": "Name of the template that the mail server should use when generating the email body."
+				},
+				"From": {
+					"type": "string",
+					"description": "Custom from variable to be used by mailer service."
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Lightly document the `reset_password_start` endpoint, with focus on `SendMailDetails`.

Adds `SendMailDetails` to config schema.