### PR TITLE
Ensure records does not duplicate on user audit trail.

### DIFF
--- a/auth/http.go
+++ b/auth/http.go
@@ -252,7 +252,8 @@ func (x *ImqsCentral) RunHttp() error {
 
 	server := &http.Server{}
 	server.Handler = smux
-	server.Addr = x.Config.Authaus.HTTP.Bind + ":" + x.Config.Authaus.HTTP.Port
+	// server.Addr = x.Config.Authaus.HTTP.Bind + ":" + x.Config.Authaus.HTTP.Port
+	server.Addr = "0.0.0.0" + ":" + x.Config.Authaus.HTTP.Port
 
 	x.Central.Log.Infof("ImqsAuth is trying to listen on %v:%v", x.Config.Authaus.HTTP.Bind, x.Config.Authaus.HTTP.Port)
 
@@ -1437,12 +1438,12 @@ func httpHandlerSetUserGroups(central *ImqsCentral, w http.ResponseWriter, r *ht
 
 			// Add the groups to the message if any groups were added
 			if len(groupsToAdd) > 0 {
-				logMessage += " Groups added: " + strings.Join(groupsToAdd, ",") + "."
+				logMessage += " Permissions added: " + strings.Join(groupsToAdd, ",") + "."
 			}
 
 			// Add the groups to the message if any groups were removed
 			if len(groupsToRemove) > 0 {
-				logMessage += " Groups removed: " + strings.Join(groupsToRemove, ",") + "."
+				logMessage += " Permissions removed: " + strings.Join(groupsToRemove, ",") + "."
 			}
 
 			auditUserLogAction(central, r, user.UserId, user.Username, logMessage, authaus.AuditActionUpdated)

--- a/auth/http.go
+++ b/auth/http.go
@@ -252,8 +252,7 @@ func (x *ImqsCentral) RunHttp() error {
 
 	server := &http.Server{}
 	server.Handler = smux
-	// server.Addr = x.Config.Authaus.HTTP.Bind + ":" + x.Config.Authaus.HTTP.Port
-	server.Addr = "0.0.0.0" + ":" + x.Config.Authaus.HTTP.Port
+	server.Addr = x.Config.Authaus.HTTP.Bind + ":" + x.Config.Authaus.HTTP.Port
 
 	x.Central.Log.Infof("ImqsAuth is trying to listen on %v:%v", x.Config.Authaus.HTTP.Bind, x.Config.Authaus.HTTP.Port)
 

--- a/auth/http.go
+++ b/auth/http.go
@@ -1433,16 +1433,16 @@ func httpHandlerSetUserGroups(central *ImqsCentral, w http.ResponseWriter, r *ht
 		if len(groupsToAdd) > 0 || len(groupsToRemove) > 0 {
 
 			// Prepare the audit log message for groups added
-			logMessage := "User Profile: User " + user.Username + " permissions changed."
+			logMessage := "Permissions changed for user: " + user.Username + "."
 
 			// Add the groups to the message if any groups were added
 			if len(groupsToAdd) > 0 {
-				logMessage += " Permissions added: " + strings.Join(groupsToAdd, ",") + "."
+				logMessage += " Groups added: " + strings.Join(groupsToAdd, ",") + "."
 			}
 
 			// Add the groups to the message if any groups were removed
 			if len(groupsToRemove) > 0 {
-				logMessage += " Permissions removed: " + strings.Join(groupsToRemove, ",") + "."
+				logMessage += " Groups removed: " + strings.Join(groupsToRemove, ",") + "."
 			}
 
 			auditUserLogAction(central, r, user.UserId, user.Username, logMessage, authaus.AuditActionUpdated)


### PR DESCRIPTION
Since the query that retrieves the records for the user audit trail gets run twice, once for 'User Profile' and once for 'Group' and then does a ilike to filter the records, if the Item to_what column has both 'User Profile' and 'Group' in its data it will show up twice. 

refs: NEXUS-4161