### PR TITLE
Add enabled and disabled audit user types

### DIFF
--- a/auth/http.go
+++ b/auth/http.go
@@ -1354,6 +1354,17 @@ func containsStr(list []string, str string) bool {
 	return false
 }
 
+// removeStr removes a specific string from a slice
+func removeStr(slice []string, str string) []string {
+	var result []string
+	for _, v := range slice {
+		if v != str {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
 func getIdentityGroupIDs(central *ImqsCentral, userId authaus.UserId) []authaus.GroupIDU32 {
 	if perm, e := central.Central.GetPermit(userId); e == nil {
 		if permGroups, eDecode := authaus.DecodePermit(perm.Roles); eDecode == nil {
@@ -1429,6 +1440,20 @@ func httpHandlerSetUserGroups(central *ImqsCentral, w http.ResponseWriter, r *ht
 
 	if user, err := central.Central.GetUserFromUserId(authaus.UserId(userId)); err == nil {
 
+		// If groupsToAdd contains 'enabled', then we need to log a special auditUserLogAction
+		// Also remove 'enabled' from groupsToAdd so that it is not logged as a group added
+		if containsStr(groupsToAdd, RoleGroupEnabled) {
+			auditUserLogAction(central, r, user.UserId, user.Username, "User Profile: "+user.Username+" profile enabled", authaus.AuditActionEnabled)
+			groupsToAdd = removeStr(groupsToAdd, RoleGroupEnabled)
+		}
+
+		// If groupsToRemove contains 'enabled', then we need to log a special auditUserLogAction
+		// Also remove 'enabled' from groupsToRemove so that it is not logged as a group removed
+		if containsStr(groupsToRemove, RoleGroupEnabled) {
+			auditUserLogAction(central, r, user.UserId, user.Username, "User Profile: "+user.Username+" profile disabled", authaus.AuditActionDisabled)
+			groupsToRemove = removeStr(groupsToRemove, RoleGroupEnabled)
+		}
+
 		// Only log if there are changes (i.e., either added or removed groups)
 		if len(groupsToAdd) > 0 || len(groupsToRemove) > 0 {
 
@@ -1447,17 +1472,6 @@ func httpHandlerSetUserGroups(central *ImqsCentral, w http.ResponseWriter, r *ht
 
 			auditUserLogAction(central, r, user.UserId, user.Username, logMessage, authaus.AuditActionUpdated)
 		}
-
-		// If groupsToAdd contains 'enabled', then we need to log a special auditUserLogAction
-		if containsStr(groupsToAdd, RoleGroupEnabled) {
-			auditUserLogAction(central, r, user.UserId, user.Username, "User Profile: "+user.Username+" profile enabled", authaus.AuditActionEnabled)
-		}
-
-		// If groupsToRemove contains 'enabled', then we need to log a special auditUserLogAction
-		if containsStr(groupsToRemove, RoleGroupEnabled) {
-			auditUserLogAction(central, r, user.UserId, user.Username, "User Profile: "+user.Username+" profile disabled", authaus.AuditActionDisabled)
-		}
-
 	}
 
 	summary := strings.Join(groups, ",")

--- a/auth/http.go
+++ b/auth/http.go
@@ -1447,6 +1447,17 @@ func httpHandlerSetUserGroups(central *ImqsCentral, w http.ResponseWriter, r *ht
 
 			auditUserLogAction(central, r, user.UserId, user.Username, logMessage, authaus.AuditActionUpdated)
 		}
+
+		// If groupsToAdd contains 'enabled', then we need to log a special auditUserLogAction
+		if containsStr(groupsToAdd, RoleGroupEnabled) {
+			auditUserLogAction(central, r, user.UserId, user.Username, "User Profile: "+user.Username+" profile enabled", authaus.AuditActionEnabled)
+		}
+
+		// If groupsToRemove contains 'enabled', then we need to log a special auditUserLogAction
+		if containsStr(groupsToRemove, RoleGroupEnabled) {
+			auditUserLogAction(central, r, user.UserId, user.Username, "User Profile: "+user.Username+" profile disabled", authaus.AuditActionDisabled)
+		}
+
 	}
 
 	summary := strings.Join(groups, ",")

--- a/auth/http.go
+++ b/auth/http.go
@@ -1433,16 +1433,16 @@ func httpHandlerSetUserGroups(central *ImqsCentral, w http.ResponseWriter, r *ht
 		if len(groupsToAdd) > 0 || len(groupsToRemove) > 0 {
 
 			// Prepare the audit log message for groups added
-			logMessage := "Permissions changed for user: " + user.Username + "."
+			logMessage := "User Profile: " + user.Username + " roles changed."
 
 			// Add the groups to the message if any groups were added
 			if len(groupsToAdd) > 0 {
-				logMessage += " Groups added: " + strings.Join(groupsToAdd, ",") + "."
+				logMessage += " Roles added: " + strings.Join(groupsToAdd, ",") + "."
 			}
 
 			// Add the groups to the message if any groups were removed
 			if len(groupsToRemove) > 0 {
-				logMessage += " Groups removed: " + strings.Join(groupsToRemove, ",") + "."
+				logMessage += " Roles removed: " + strings.Join(groupsToRemove, ",") + "."
 			}
 
 			auditUserLogAction(central, r, user.UserId, user.Username, logMessage, authaus.AuditActionUpdated)


### PR DESCRIPTION
Create a special use case for the adding and removing of the ‘enabled’ permission. Add two new action types: Disabled: User Profile and Enabled: User Profile to the audit trail.

refs: NEXUS-4244