### PR TITLE
feat: Fetches IMQS_HOSTNAME_URL from configservice

### DIFF
--- a/imqsauth.go
+++ b/imqsauth.go
@@ -100,7 +100,7 @@ func exec(cmd string, args []string, options cli.OptionSet) int {
 	// Try test config first; otherwise load real config
 	isTestConfig := auth.LoadTestConfig(ic, configFile)
 	if !isTestConfig {
-		if err := ic.Config.LoadFile(configFile); err != nil {
+		if err := ic.Config.LoadConfig(configFile); err != nil {
 			panic(fmt.Sprintf("Error loading config file '%v': %v", configFile, err))
 		}
 


### PR DESCRIPTION
Conforming to the pattern that all IMQS services should fetch environment variables from configservice.

This should only be merged after [configservice PR](https://github.com/IMQS/configservice/pull/29) was merged.
This is to ensure that the URL construction is still correct.

Refs: ASG-4927